### PR TITLE
feat: fix images for prod page

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/assets/images/BroserTabLogo/favicon.ico" />
+    <link rel="icon" type="image/png" href="/assets/images/BrowserTabLogo/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <!-- Google Ads -->

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { AdSlot } from "./components/AdSlot";
 import { RoutePlanner } from "./features/RoutePlanner/RoutePlanner";
+import logoUrl from "./assets/images/DGRoutePlannerCropped.png";
 
 export default function App() {
   const isDev = import.meta.env.DEV;
@@ -31,7 +32,7 @@ export default function App() {
         <div className="container mx-auto px-4 py-4">
           <div className="flex items-center gap-3">
             <img
-              src="/src/assets/images/DGRoutePlannerCropped.png"
+              src={logoUrl}
               alt="DGRoutePlanner Logo"
               className="h-14 w-14 object-contain"
             />


### PR DESCRIPTION
## fix(app): bundle header logo so it loads in production

- Replaced `/src/...` image path with Vite import:
  `import logoUrl from "./assets/images/DGRoutePlannerCropped.png";`
- Ensures the logo is copied & hashed by Vite and no longer 404s in prod.
- No visual changes other than the logo now appearing reliably.
